### PR TITLE
Fix: Constructor in Java class files now include missing headers

### DIFF
--- a/src/main/java/com/contentstack/cms/stack/Alias.java
+++ b/src/main/java/com/contentstack/cms/stack/Alias.java
@@ -35,8 +35,9 @@ public class Alias implements BaseImplementation<Alias> {
     // also creates an
     // instance of the `AliasService` interface using the provided `Retrofit`
     // instance.
-    protected Alias(Retrofit instance) {
+    protected Alias(Retrofit instance,Map<String, Object> headers) {
         this.headers = new HashMap<>();
+        this.headers.putAll(headers);
         this.headers.put("Content-Type", "application/json");
         params = new HashMap<>();
         this.service = instance.create(AliasService.class);
@@ -45,8 +46,9 @@ public class Alias implements BaseImplementation<Alias> {
     // The `protected Alias(Retrofit instance, String aliasUid)` constructor is used
     // to create an
     // instance of the `Alias` class with a specific alias UID.
-    protected Alias(Retrofit instance, String aliasUid) {
+    protected Alias(Retrofit instance,Map<String, Object> headers, String aliasUid) {
         this.headers = new HashMap<>();
+        this.headers.putAll(headers);
         this.headers.put("Content-Type", "application/json");
         params = new HashMap<>();
         this.uid = aliasUid;

--- a/src/main/java/com/contentstack/cms/stack/Asset.java
+++ b/src/main/java/com/contentstack/cms/stack/Asset.java
@@ -117,7 +117,7 @@ public class Asset implements BaseImplementation<Asset> {
      * @return Folder
      */
     public Folder folder() {
-        return new Folder(this.instance);
+        return new Folder(this.instance,this.headers);
     }
 
     /**
@@ -127,7 +127,7 @@ public class Asset implements BaseImplementation<Asset> {
      * @return Folder
      */
     public Folder folder(@NotNull String folderUid) {
-        return new Folder(this.instance, folderUid);
+        return new Folder(this.instance,this.headers, folderUid);
     }
 
     /**

--- a/src/main/java/com/contentstack/cms/stack/AuditLog.java
+++ b/src/main/java/com/contentstack/cms/stack/AuditLog.java
@@ -7,6 +7,7 @@ import retrofit2.Call;
 import retrofit2.Retrofit;
 
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -37,14 +38,16 @@ public class AuditLog implements BaseImplementation<AuditLog> {
     protected HashMap<String, Object> params;
     private String logItemUid;
 
-    protected AuditLog(Retrofit retrofit) {
+    protected AuditLog(Retrofit retrofit,Map<String, Object> headers) {
         this.headers = new HashMap<>();
+        this.headers.putAll(headers);
         this.params = new HashMap<>();
         this.service = retrofit.create(AuditLogService.class);
     }
 
-    protected AuditLog(Retrofit retrofit, String uid) {
+    protected AuditLog(Retrofit retrofit,Map<String, Object> headers, String uid) {
         this.headers = new HashMap<>();
+        this.headers.putAll(headers);
         this.params = new HashMap<>();
         this.logItemUid = uid;
         this.service = retrofit.create(AuditLogService.class);

--- a/src/main/java/com/contentstack/cms/stack/Branch.java
+++ b/src/main/java/com/contentstack/cms/stack/Branch.java
@@ -34,15 +34,17 @@ public class Branch implements BaseImplementation<Branch> {
     private Retrofit instance;
     private String baseBranchId;
 
-    protected Branch(Retrofit instance) {
+    protected Branch(Retrofit instance,Map<String, Object> headers) {
         this.headers = new HashMap<>();
+        this.headers.putAll(headers);
         this.headers.put("Content-Type", "application/json");
         this.params = new HashMap<>();
         this.service = instance.create(BranchService.class);
     }
 
-    protected Branch(Retrofit instance, String uid) {
+    protected Branch(Retrofit instance,Map<String, Object> headers, String uid) {
         this.headers = new HashMap<>();
+        this.headers.putAll(headers);
         this.headers.put("Content-Type", "application/json");
         this.baseBranchId = uid;
         this.params = new HashMap<>();

--- a/src/main/java/com/contentstack/cms/stack/BulkOperation.java
+++ b/src/main/java/com/contentstack/cms/stack/BulkOperation.java
@@ -8,6 +8,7 @@ import retrofit2.Call;
 import retrofit2.Retrofit;
 
 import java.util.HashMap;
+import java.util.Map;
 
 /**
  * You can perform bulk operations such as Publish, Unpublished, and Delete on
@@ -48,8 +49,9 @@ public class BulkOperation implements BaseImplementation<BulkOperation> {
      *
      * @param retrofit the retrofit
      */
-    protected BulkOperation(Retrofit retrofit) {
+    protected BulkOperation(Retrofit retrofit,Map<String, Object> headers) {
         this.headers = new HashMap<>();
+        this.headers.putAll(headers);
         this.params = new HashMap<>();
         this.retrofit = retrofit;
         this.service = this.retrofit.create(BulkOperationService.class);

--- a/src/main/java/com/contentstack/cms/stack/DeliveryToken.java
+++ b/src/main/java/com/contentstack/cms/stack/DeliveryToken.java
@@ -7,6 +7,7 @@ import org.json.simple.JSONObject;
 import retrofit2.Call;
 
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -31,14 +32,16 @@ public class DeliveryToken implements BaseImplementation<DeliveryToken> {
     private String tokenUid;
     String ERROR = "Token UID Can Not Be Null OR Empty";
 
-    protected DeliveryToken(TokenService service) {
+    protected DeliveryToken(TokenService service, Map<String, Object> headers) {
         this.headers = new HashMap<>();
+        this.headers.putAll(headers);
         this.params = new HashMap<>();
         this.service = service;
     }
 
-    protected DeliveryToken(TokenService service, @NotNull String tokenUid) {
+    protected DeliveryToken(TokenService service, Map<String, Object> headers, @NotNull String tokenUid) {
         this.headers = new HashMap<>();
+        this.headers.putAll(headers);
         this.params = new HashMap<>();
         this.tokenUid = tokenUid;
         this.service = service;

--- a/src/main/java/com/contentstack/cms/stack/Environment.java
+++ b/src/main/java/com/contentstack/cms/stack/Environment.java
@@ -27,15 +27,17 @@ public class Environment implements BaseImplementation<Environment> {
     protected final EnvironmentService service;
     protected String environment;
 
-    protected Environment(Retrofit instance) {
+    protected Environment(Retrofit instance, Map<String, Object> headers) {
         this.headers = new HashMap<>();
+        this.headers.putAll(headers);
         this.params = new HashMap<>();
         this.service = instance.create(EnvironmentService.class);
     }
 
-    protected Environment(Retrofit instance, String environment) {
+    protected Environment(Retrofit instance, Map<String, Object> headers, String environment) {
         this.environment = environment;
         this.headers = new HashMap<>();
+        this.headers.putAll(headers);
         this.params = new HashMap<>();
         this.service = instance.create(EnvironmentService.class);
     }

--- a/src/main/java/com/contentstack/cms/stack/Extensions.java
+++ b/src/main/java/com/contentstack/cms/stack/Extensions.java
@@ -36,14 +36,16 @@ public class Extensions implements BaseImplementation<Extensions> {
     protected HashMap<String, Object> params;
     protected String customFieldUid;
 
-    protected Extensions(Retrofit retrofit) {
+    protected Extensions(Retrofit retrofit,Map<String, Object> headers) {
         this.headers = new HashMap<>();
+        this.headers.putAll(headers);
         this.params = new HashMap<>();
         this.service = retrofit.create(ExtensionsService.class);
     }
 
-    protected Extensions(Retrofit retrofit, String fieldUid) {
+    protected Extensions(Retrofit retrofit,Map<String, Object> headers, String fieldUid) {
         this.headers = new HashMap<>();
+        this.headers.putAll(headers);
         this.params = new HashMap<>();
         this.customFieldUid = fieldUid;
         this.service = retrofit.create(ExtensionsService.class);

--- a/src/main/java/com/contentstack/cms/stack/Folder.java
+++ b/src/main/java/com/contentstack/cms/stack/Folder.java
@@ -18,14 +18,16 @@ public class Folder implements BaseImplementation<Folder> {
     protected final AssetService service;
     private String folderUid;
 
-    protected Folder(Retrofit instance) {
+    protected Folder(Retrofit instance,Map<String, Object> headers) {
         this.headers = new HashMap<>();
+        this.headers.putAll(headers);
         params = new HashMap<>();
         this.service = instance.create(AssetService.class);
     }
 
-    protected Folder(Retrofit instance, String folderUid) {
+    protected Folder(Retrofit instance,Map<String, Object> headers, String folderUid) {
         this.headers = new HashMap<>();
+        this.headers.putAll(headers);
         params = new HashMap<>();
         this.folderUid = folderUid;
         this.service = instance.create(AssetService.class);

--- a/src/main/java/com/contentstack/cms/stack/GlobalField.java
+++ b/src/main/java/com/contentstack/cms/stack/GlobalField.java
@@ -8,6 +8,7 @@ import retrofit2.Call;
 import retrofit2.Retrofit;
 
 import java.util.HashMap;
+import java.util.Map;
 
 /**
  * A Global field is a reusable field (or group of fields) that you can define
@@ -37,14 +38,16 @@ public class GlobalField implements BaseImplementation<GlobalField> {
     protected HashMap<String, Object> params;
     protected String globalFiledUid;
 
-    protected GlobalField(Retrofit retrofit) {
+    protected GlobalField(Retrofit retrofit,Map<String, Object> headers) {
         this.headers = new HashMap<>();
+        this.headers.putAll(headers);
         this.params = new HashMap<>();
         this.service = retrofit.create(GlobalFieldService.class);
     }
 
-    protected GlobalField(Retrofit retrofit, String uid) {
+    protected GlobalField(Retrofit retrofit,Map<String, Object> headers, String uid) {
         this.headers = new HashMap<>();
+        this.headers.putAll(headers);
         this.params = new HashMap<>();
         this.globalFiledUid = uid;
         this.service = retrofit.create(GlobalFieldService.class);

--- a/src/main/java/com/contentstack/cms/stack/Label.java
+++ b/src/main/java/com/contentstack/cms/stack/Label.java
@@ -8,6 +8,7 @@ import retrofit2.Call;
 import retrofit2.Retrofit;
 
 import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Labels allow you to group a collection of content within a stack. Using
@@ -32,15 +33,17 @@ public class Label implements BaseImplementation<Label> {
     protected HashMap<String, Object> params;
     protected String labelUid;
 
-    protected Label(Retrofit retrofit) {
+    protected Label(Retrofit retrofit,Map<String, Object> headers) {
         this.headers = new HashMap<>();
+        this.headers.putAll(headers);
         this.params = new HashMap<>();
         this.service = retrofit.create(LabelService.class);
     }
 
-    protected Label(Retrofit retrofit, String labelUid) {
+    protected Label(Retrofit retrofit,Map<String, Object> headers, String labelUid) {
         this.labelUid = labelUid;
         this.headers = new HashMap<>();
+        this.headers.putAll(headers);
         this.params = new HashMap<>();
         this.service = retrofit.create(LabelService.class);
     }

--- a/src/main/java/com/contentstack/cms/stack/Locale.java
+++ b/src/main/java/com/contentstack/cms/stack/Locale.java
@@ -38,14 +38,16 @@ public class Locale implements BaseImplementation<Locale> {
      *
      * @param client the retrofit client
      */
-    public Locale(Retrofit client) {
+    public Locale(Retrofit client,Map<String, Object> headers) {
         this.headers = new HashMap<>();
+        this.headers.putAll(headers);
         this.params = new HashMap<>();
         this.localeService = client.create(LocaleService.class);
     }
 
-    public Locale(Retrofit client, String code) {
+    public Locale(Retrofit client,Map<String, Object> headers, String code) {
         this.headers = new HashMap<>();
+        this.headers.putAll(headers);
         this.code = code;
         this.params = new HashMap<>();
         this.localeService = client.create(LocaleService.class);

--- a/src/main/java/com/contentstack/cms/stack/ManagementToken.java
+++ b/src/main/java/com/contentstack/cms/stack/ManagementToken.java
@@ -7,6 +7,7 @@ import org.json.simple.JSONObject;
 import retrofit2.Call;
 
 import java.util.HashMap;
+import java.util.Map;
 
 /**
  * To authenticate Content Management API (CMA) requests over your stack
@@ -24,14 +25,16 @@ public class ManagementToken implements BaseImplementation<ManagementToken> {
     protected HashMap<String, Object> params;
     private String tokenUid;
 
-    protected ManagementToken(TokenService service) {
+    protected ManagementToken(TokenService service,Map<String, Object> headers) {
         this.headers = new HashMap<>();
+        this.headers.putAll(headers);
         this.params = new HashMap<>();
         this.service = service;
     }
 
-    protected ManagementToken(TokenService service, String tokenUid) {
+    protected ManagementToken(TokenService service,Map<String, Object> headers, String tokenUid) {
         this.headers = new HashMap<>();
+        this.headers.putAll(headers);
         this.params = new HashMap<>();
         this.service = service;
         this.tokenUid = tokenUid;

--- a/src/main/java/com/contentstack/cms/stack/PublishQueue.java
+++ b/src/main/java/com/contentstack/cms/stack/PublishQueue.java
@@ -7,6 +7,7 @@ import retrofit2.Call;
 import retrofit2.Retrofit;
 
 import java.util.HashMap;
+import java.util.Map;
 
 /**
  * The Publish Queue displays the historical and current details of activities
@@ -44,15 +45,17 @@ public class PublishQueue implements BaseImplementation<PublishQueue> {
     private String publishQueueUid;
     private final Retrofit retrofit;
 
-    protected PublishQueue(Retrofit retrofit) {
+    protected PublishQueue(Retrofit retrofit,Map<String, Object> headers) {
         this.headers = new HashMap<>();
+        this.headers.putAll(headers);
         this.params = new HashMap<>();
         this.retrofit = retrofit;
         this.service = this.retrofit.create(PublishQueueService.class);
     }
 
-    protected PublishQueue(Retrofit retrofit, String uid) {
+    protected PublishQueue(Retrofit retrofit,Map<String, Object> headers, String uid) {
         this.headers = new HashMap<>();
+        this.headers.putAll(headers);
         this.params = new HashMap<>();
         this.retrofit = retrofit;
         this.publishQueueUid = uid;

--- a/src/main/java/com/contentstack/cms/stack/Release.java
+++ b/src/main/java/com/contentstack/cms/stack/Release.java
@@ -8,6 +8,7 @@ import retrofit2.Call;
 import retrofit2.Retrofit;
 
 import java.util.HashMap;
+import java.util.Map;
 
 /**
  * You can pin a set of entries and assets (along with the deploy action, i.e.,
@@ -38,15 +39,17 @@ public class Release implements BaseImplementation<Release> {
     protected String releaseUid;
     private final Retrofit retrofit;
 
-    protected Release(Retrofit retrofit) {
+    protected Release(Retrofit retrofit,Map<String, Object> headers) {
         this.headers = new HashMap<>();
+        this.headers.putAll(headers);
         this.params = new HashMap<>();
         this.retrofit = retrofit;
         this.service = this.retrofit.create(ReleaseService.class);
     }
 
-    protected Release(Retrofit retrofit, String uid) {
+    protected Release(Retrofit retrofit,Map<String, Object> headers, String uid) {
         this.headers = new HashMap<>();
+        this.headers.putAll(headers);
         this.params = new HashMap<>();
         this.releaseUid = uid;
         this.retrofit = retrofit;
@@ -254,7 +257,7 @@ public class Release implements BaseImplementation<Release> {
      */
     public ReleaseItem item() {
         validate();
-        return new ReleaseItem(this.retrofit, this.releaseUid);
+        return new ReleaseItem(this.retrofit,this.headers, this.releaseUid);
     }
 
     /**

--- a/src/main/java/com/contentstack/cms/stack/ReleaseItem.java
+++ b/src/main/java/com/contentstack/cms/stack/ReleaseItem.java
@@ -8,6 +8,7 @@ import retrofit2.Call;
 import retrofit2.Retrofit;
 
 import java.util.HashMap;
+import java.util.Map;
 
 /**
  * The Get all items in a Release request retrieves a list of all items (entries
@@ -29,8 +30,9 @@ public class ReleaseItem implements BaseImplementation<ReleaseItem> {
     protected HashMap<String, Object> params;
     private final String releaseUid;
 
-    protected ReleaseItem(Retrofit retrofit, String releaseUid) {
+    protected ReleaseItem(Retrofit retrofit,Map<String, Object> headers, String releaseUid) {
         this.headers = new HashMap<>();
+        this.headers.putAll(headers);
         this.params = new HashMap<>();
         this.releaseUid = releaseUid;
         this.service = retrofit.create(ReleaseService.class);

--- a/src/main/java/com/contentstack/cms/stack/Roles.java
+++ b/src/main/java/com/contentstack/cms/stack/Roles.java
@@ -8,6 +8,7 @@ import retrofit2.Call;
 import retrofit2.Retrofit;
 
 import java.util.HashMap;
+import java.util.Map;
 
 /**
  * A role is a collection of permissions that will be applicable to all the
@@ -27,14 +28,16 @@ public class Roles implements BaseImplementation<Roles> {
     protected HashMap<String, Object> params;
     protected String roleUid;
 
-    protected Roles(Retrofit retrofit) {
+    protected Roles(Retrofit retrofit,Map<String, Object> headers) {
         this.headers = new HashMap<>();
+        this.headers.putAll(headers);
         this.params = new HashMap<>();
         this.service = retrofit.create(RolesService.class);
     }
 
-    protected Roles(Retrofit retrofit, String roleUid) {
+    protected Roles(Retrofit retrofit,Map<String, Object> headers, String roleUid) {
         this.headers = new HashMap<>();
+        this.headers.putAll(headers);
         this.params = new HashMap<>();
         this.roleUid = roleUid;
         this.service = retrofit.create(RolesService.class);

--- a/src/main/java/com/contentstack/cms/stack/Stack.java
+++ b/src/main/java/com/contentstack/cms/stack/Stack.java
@@ -360,7 +360,7 @@ public class Stack implements BaseImplementation<Stack> {
      * @return GlobalField
      */
     public GlobalField globalField() {
-        return new GlobalField(this.client);
+        return new GlobalField(this.client,this.headers);
     }
 
     /**
@@ -374,7 +374,7 @@ public class Stack implements BaseImplementation<Stack> {
      * @return GlobalField
      */
     public GlobalField globalField(@NotNull String globalFiledUid) {
-        return new GlobalField(this.client, globalFiledUid);
+        return new GlobalField(this.client,this.headers,globalFiledUid);
     }
 
     /**
@@ -390,7 +390,7 @@ public class Stack implements BaseImplementation<Stack> {
      * "https://www.contentstack.com/docs/developers/multilingual-content">Languages</a>
      */
     public Locale locale() {
-        return new Locale(this.client);
+        return new Locale(this.client,this.headers);
     }
 
     /**
@@ -407,7 +407,7 @@ public class Stack implements BaseImplementation<Stack> {
      * "https://www.contentstack.com/docs/developers/multilingual-content">Languages</a>
      */
     public Locale locale(String code) {
-        return new Locale(this.client, code);
+        return new Locale(this.client,this.headers, code);
     }
 
     /**
@@ -422,7 +422,7 @@ public class Stack implements BaseImplementation<Stack> {
      * "https://www.contentstack.com/docs/developers/set-up-environments">Environments</a>
      */
     public Environment environment() {
-        return new Environment(this.client);
+        return new Environment(this.client,this.headers);
     }
 
     /**
@@ -438,7 +438,7 @@ public class Stack implements BaseImplementation<Stack> {
      * "https://www.contentstack.com/docs/developers/set-up-environments">Environments</a>
      */
     public Environment environment(String environment) {
-        return new Environment(this.client, environment);
+        return new Environment(this.client,this.headers, environment);
     }
 
     /**
@@ -457,7 +457,7 @@ public class Stack implements BaseImplementation<Stack> {
      * module resides.
      */
     public Label label() {
-        return new Label(this.client);
+        return new Label(this.client,this.headers);
     }
 
     /**
@@ -477,7 +477,7 @@ public class Stack implements BaseImplementation<Stack> {
      * module resides.
      */
     public Label label(String labelUid) {
-        return new Label(this.client, labelUid);
+        return new Label(this.client,this.headers, labelUid);
     }
 
     /**
@@ -497,7 +497,7 @@ public class Stack implements BaseImplementation<Stack> {
      * @return instance of {@link Extensions}
      */
     public Extensions extensions() {
-        return new Extensions(this.client);
+        return new Extensions(this.client,this.headers);
     }
 
     /**
@@ -522,7 +522,7 @@ public class Stack implements BaseImplementation<Stack> {
      * @return instance of {@link Extensions}
      */
     public Extensions extensions(String customFieldUid) {
-        return new Extensions(this.client, customFieldUid);
+        return new Extensions(this.client,this.headers, customFieldUid);
     }
 
     /**
@@ -543,7 +543,7 @@ public class Stack implements BaseImplementation<Stack> {
      * @return Tokens
      */
     public Tokens tokens() {
-        return new Tokens(this.client);
+        return new Tokens(this.client,this.headers);
     }
 
     /**
@@ -553,7 +553,7 @@ public class Stack implements BaseImplementation<Stack> {
      * @return Role
      */
     public Roles roles() {
-        return new Roles(this.client);
+        return new Roles(this.client,this.headers);
     }
 
     /**
@@ -565,7 +565,7 @@ public class Stack implements BaseImplementation<Stack> {
      * @return Role
      */
     public Roles roles(String roleUid) {
-        return new Roles(this.client, roleUid);
+        return new Roles(this.client, this.headers,roleUid);
     }
 
     /**
@@ -578,7 +578,7 @@ public class Stack implements BaseImplementation<Stack> {
      * @return Release
      */
     public Release releases() {
-        return new Release(this.client);
+        return new Release(this.client,this.headers);
     }
 
     /**
@@ -593,7 +593,7 @@ public class Stack implements BaseImplementation<Stack> {
      * @return Release
      */
     public Release releases(String releaseUid) {
-        return new Release(this.client, releaseUid);
+        return new Release(this.client,this.headers,releaseUid);
     }
 
     /**
@@ -607,7 +607,7 @@ public class Stack implements BaseImplementation<Stack> {
      * @return Workflow
      */
     public Workflow workflow() {
-        return new Workflow(this.client);
+        return new Workflow(this.client,this.headers);
     }
 
     /**
@@ -622,7 +622,7 @@ public class Stack implements BaseImplementation<Stack> {
      * @return Workflow
      */
     public Workflow workflow(@NotNull String workflowUid) {
-        return new Workflow(this.client, workflowUid);
+        return new Workflow(this.client, this.headers,workflowUid);
     }
 
     /**
@@ -635,7 +635,7 @@ public class Stack implements BaseImplementation<Stack> {
      * @return AuditLog
      */
     public AuditLog auditLog() {
-        return new AuditLog(this.client);
+        return new AuditLog(this.client,this.headers);
     }
 
     /**
@@ -649,7 +649,7 @@ public class Stack implements BaseImplementation<Stack> {
      * @return AuditLog
      */
     public AuditLog auditLog(@NotNull String logItemUid) {
-        return new AuditLog(this.client, logItemUid);
+        return new AuditLog(this.client,this.headers, logItemUid);
     }
 
     /**
@@ -668,7 +668,7 @@ public class Stack implements BaseImplementation<Stack> {
      * @return PublishQueue
      */
     public PublishQueue publishQueue() {
-        return new PublishQueue(this.client);
+        return new PublishQueue(this.client,this.headers);
     }
 
     /**
@@ -684,7 +684,7 @@ public class Stack implements BaseImplementation<Stack> {
      * @return BulkOperation
      */
     public BulkOperation bulkOperation() {
-        return new BulkOperation(this.client);
+        return new BulkOperation(this.client,this.headers);
     }
 
     /**
@@ -707,7 +707,7 @@ public class Stack implements BaseImplementation<Stack> {
      * @return PublishQueue
      */
     public PublishQueue publishQueue(@NotNull String publishQueueUid) {
-        return new PublishQueue(this.client, publishQueueUid);
+        return new PublishQueue(this.client,this.headers, publishQueueUid);
     }
 
     /**
@@ -731,7 +731,7 @@ public class Stack implements BaseImplementation<Stack> {
      * @return Webhook
      */
     public Webhook webhook() {
-        return new Webhook(this.client);
+        return new Webhook(this.client,this.headers);
     }
 
     /**
@@ -758,7 +758,7 @@ public class Stack implements BaseImplementation<Stack> {
      * @return Webhook
      */
     public Webhook webhook(String webhookUid) {
-        return new Webhook(this.client, webhookUid);
+        return new Webhook(this.client,this.headers, webhookUid);
     }
 
     /**
@@ -774,7 +774,7 @@ public class Stack implements BaseImplementation<Stack> {
      * @return Branch
      */
     public Branch branch() {
-        return new Branch(this.client);
+        return new Branch(this.client,this.headers);
     }
 
     /**
@@ -792,7 +792,7 @@ public class Stack implements BaseImplementation<Stack> {
      * @return Branch
      */
     public Branch branch(String branchUid) {
-        return new Branch(this.client, branchUid);
+        return new Branch(this.client,this.headers, branchUid);
     }
 
     /**
@@ -803,7 +803,7 @@ public class Stack implements BaseImplementation<Stack> {
      * @return Alias
      */
     public Alias alias() {
-        return new Alias(this.client);
+        return new Alias(this.client,this.headers);
     }
 
     /**
@@ -818,7 +818,7 @@ public class Stack implements BaseImplementation<Stack> {
      * @return Alias
      */
     public Alias alias(String aliasUid) {
-        return new Alias(this.client, aliasUid);
+        return new Alias(this.client, this.headers,aliasUid);
     }
 
 

--- a/src/main/java/com/contentstack/cms/stack/Taxonomy.java
+++ b/src/main/java/com/contentstack/cms/stack/Taxonomy.java
@@ -42,6 +42,7 @@ public class Taxonomy implements BaseImplementation<Taxonomy> {
      */
     protected Taxonomy(Retrofit client, HashMap<String, Object> headers) {
         this.headers = new HashMap<>();
+        this.headers.putAll(headers);
         this.params = new HashMap<>();
         this.headers.putAll(headers);
         this.taxonomyService = client.create(TaxonomyService.class);
@@ -56,6 +57,7 @@ public class Taxonomy implements BaseImplementation<Taxonomy> {
      */
     protected Taxonomy(Retrofit client, HashMap<String, Object> headers, @NotNull String taxonomyId) {
         this.headers = new HashMap<>();
+        this.headers.putAll(headers);
         this.params = new HashMap<>();
         this.taxonomyId = taxonomyId;
         this.headers.putAll(headers);

--- a/src/main/java/com/contentstack/cms/stack/TokenService.java
+++ b/src/main/java/com/contentstack/cms/stack/TokenService.java
@@ -10,53 +10,53 @@ import java.util.Map;
 public interface TokenService {
 
     // Delivery Tokens
-    @GET("delivery_tokens")
+    @GET("stacks/delivery_tokens")
     Call<ResponseBody> getDeliveryToken(
             @HeaderMap Map<String, Object> headers);
 
-    @GET("delivery_tokens/{token_uid}")
+    @GET("stacks/delivery_tokens/{token_uid}")
     Call<ResponseBody> getDeliveryToken(
             @HeaderMap Map<String, Object> headers,
             @Path("token_uid") String tokenUid);
 
-    @POST("delivery_tokens")
+    @POST("stacks/delivery_tokens")
     Call<ResponseBody> createDeliveryToken(
             @HeaderMap Map<String, Object> headers,
             @Body JSONObject body);
 
-    @PUT("delivery_tokens/{token_uid}")
+    @PUT("stacks/delivery_tokens/{token_uid}")
     Call<ResponseBody> updateDeliveryToken(
             @HeaderMap Map<String, Object> headers,
             @Path("token_uid") String tokenUid,
             @Body JSONObject body);
 
-    @DELETE("delivery_tokens/{token_uid}")
+    @DELETE("stacks/delivery_tokens/{token_uid}")
     Call<ResponseBody> deleteDeliveryToken(
             @HeaderMap Map<String, Object> headers,
             @Path("token_uid") String tokenUid,
             @Query("force") Boolean force);
 
     // Management Tokens
-    @GET("management_tokens")
+    @GET("stacks/management_tokens")
     Call<ResponseBody> fetchManagementToken(
             @HeaderMap Map<String, Object> headers, @QueryMap Map<String, Object> params);
 
-    @GET("management_tokens/{token_uid}")
+    @GET("stacks/management_tokens/{token_uid}")
     Call<ResponseBody> getSingleManagementToken(
             @HeaderMap Map<String, Object> headers,
             @Path("token_uid") String tokenUid);
 
-    @POST("management_tokens")
+    @POST("stacks/management_tokens")
     Call<ResponseBody> createManagementToken(
             @HeaderMap Map<String, Object> headers,
             @Body JSONObject body);
 
-    @PUT("management_tokens/{token_uid}")
+    @PUT("stacks/management_tokens/{token_uid}")
     Call<ResponseBody> updateManagementToken(
             @HeaderMap Map<String, Object> headers,
             @Path("token_uid") String tokenUid, @Body JSONObject body);
 
-    @DELETE("management_tokens/{token_uid}")
+    @DELETE("stacks/management_tokens/{token_uid}")
     Call<ResponseBody> deleteManagementToken(
             @HeaderMap Map<String, Object> headers,
             @Path("token_uid") String tokenUid);

--- a/src/main/java/com/contentstack/cms/stack/Tokens.java
+++ b/src/main/java/com/contentstack/cms/stack/Tokens.java
@@ -1,5 +1,7 @@
 package com.contentstack.cms.stack;
 
+import java.util.Map;
+
 import org.jetbrains.annotations.NotNull;
 import retrofit2.Retrofit;
 
@@ -13,9 +15,11 @@ import retrofit2.Retrofit;
 public class Tokens {
 
     protected final TokenService service;
+     protected final Map<String, Object> headers;
 
-    protected Tokens(Retrofit retrofit) {
+    protected Tokens(Retrofit retrofit,Map<String, Object> headers) {
         this.service = retrofit.create(TokenService.class);
+        this.headers = headers;
     }
 
     /**
@@ -32,7 +36,7 @@ public class Tokens {
      * @since 0.1.0
      */
     public DeliveryToken deliveryTokens() {
-        return new DeliveryToken(this.service);
+        return new DeliveryToken(this.service,this.headers);
     }
 
     /**
@@ -51,7 +55,7 @@ public class Tokens {
      * @since 0.1.0
      */
     public DeliveryToken deliveryTokens(@NotNull String tokenUid) {
-        return new DeliveryToken(this.service, tokenUid);
+        return new DeliveryToken(this.service,this.headers, tokenUid);
     }
 
     /**
@@ -66,7 +70,7 @@ public class Tokens {
      * @since 0.1.0
      */
     public ManagementToken managementToken() {
-        return new ManagementToken(this.service);
+        return new ManagementToken(this.service,this.headers);
     }
 
     /**
@@ -82,7 +86,7 @@ public class Tokens {
      * @since 0.1.0
      */
     public ManagementToken managementToken(@NotNull String managementTokenUid) {
-        return new ManagementToken(this.service, managementTokenUid);
+        return new ManagementToken(this.service,this.headers, managementTokenUid);
     }
 
 }

--- a/src/main/java/com/contentstack/cms/stack/Webhook.java
+++ b/src/main/java/com/contentstack/cms/stack/Webhook.java
@@ -12,6 +12,7 @@ import retrofit2.Call;
 import retrofit2.Retrofit;
 
 import java.util.HashMap;
+import java.util.Map;
 
 /**
  * A webhook is a mechanism that sends real-time information to any third-party
@@ -38,14 +39,16 @@ public class Webhook implements BaseImplementation<Webhook> {
     protected HashMap<String, Object> params;
     private String webhookUid;
 
-    protected Webhook(Retrofit retrofit) {
+    protected Webhook(Retrofit retrofit,Map<String, Object> headers) {
         this.headers = new HashMap<>();
+        this.headers.putAll(headers);
         this.params = new HashMap<>();
         this.service = retrofit.create(WebhookService.class);
     }
 
-    protected Webhook(Retrofit retrofit, String uid) {
+    protected Webhook(Retrofit retrofit,Map<String, Object> headers, String uid) {
         this.headers = new HashMap<>();
+        this.headers.putAll(headers);
         this.params = new HashMap<>();
         this.webhookUid = uid;
         this.service = retrofit.create(WebhookService.class);

--- a/src/main/java/com/contentstack/cms/stack/Workflow.java
+++ b/src/main/java/com/contentstack/cms/stack/Workflow.java
@@ -9,6 +9,7 @@ import retrofit2.Retrofit;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Workflow is a tool that allows you to streamline the process of content
@@ -31,15 +32,17 @@ public class Workflow implements BaseImplementation<Workflow> {
     protected HashMap<String, Object> params;
     private String workflowUid;
 
-    protected Workflow(Retrofit retrofit) {
+    protected Workflow(Retrofit retrofit,Map<String, Object> headers) {
         this.headers = new HashMap<>();
+        this.headers.putAll(headers);
         this.params = new HashMap<>();
         this.service = retrofit.create(WorkflowService.class);
     }
 
-    protected Workflow(Retrofit retrofit, @NotNull String uid) {
+    protected Workflow(Retrofit retrofit,Map<String, Object> headers, @NotNull String uid) {
         this.workflowUid = uid;
         this.headers = new HashMap<>();
+        this.headers.putAll(headers);
         this.params = new HashMap<>();
         this.service = retrofit.create(WorkflowService.class);
     }

--- a/src/test/java/com/contentstack/cms/stack/EnvironmentAPITest.java
+++ b/src/test/java/com/contentstack/cms/stack/EnvironmentAPITest.java
@@ -3,6 +3,8 @@ package com.contentstack.cms.stack;
 import com.contentstack.cms.Contentstack;
 import com.contentstack.cms.TestClient;
 import com.contentstack.cms.Utils;
+import com.contentstack.cms.core.Util;
+
 import okhttp3.ResponseBody;
 import org.json.simple.JSONObject;
 import org.junit.jupiter.api.*;
@@ -17,17 +19,21 @@ public class EnvironmentAPITest {
     protected static String API_KEY = TestClient.API_KEY;
     protected static String MANAGEMENT_TOKEN = TestClient.AUTHTOKEN;
     static Environment environment;
+    protected static Stack stackInstance;
+   
 
     @BeforeAll
     public static void setupEnv() {
-        Contentstack contentstack = new Contentstack.Builder().setAuthtoken(AUTHTOKEN).build();
-        Stack stackInstance = contentstack.stack(API_KEY, MANAGEMENT_TOKEN);
+        // Contentstack contentstack = new Contentstack.Builder().setAuthtoken(AUTHTOKEN).build();
+        // Stack stackInstance = contentstack.stack(API_KEY, MANAGEMENT_TOKEN);
+        stackInstance = TestClient.getStack().addHeader(Util.API_KEY, API_KEY)
+                .addHeader("api_key", API_KEY);
         environment = stackInstance.environment("production");
     }
 
     @Test
     @Order(1)
-    void fetchLocales() {
+    void fetchEnvironments() {
         environment.addParam("include_count", false);
         environment.addParam("asc", "created_at");
         environment.addParam("desc", "updated_at");
@@ -46,7 +52,7 @@ public class EnvironmentAPITest {
 
     @Test
     @Order(2)
-    void addLocale() {
+    void fetchEnvironment() {
         try {
             Response<ResponseBody> response = environment.fetch().execute();
             if (response.isSuccessful()) {
@@ -61,7 +67,7 @@ public class EnvironmentAPITest {
 
     @Test
     @Order(3)
-    void getLocale() {
+    void createEnvironment() {
         // add_env.json
         JSONObject requestBody = Utils.readJson("environment/add_env.json");
         try {
@@ -78,7 +84,7 @@ public class EnvironmentAPITest {
 
     @Test
     @Order(4)
-    void updateLocale() {
+    void updateEnvironment() {
         JSONObject requestBody = Utils.readJson("environment/add_env.json");
         try {
             Response<ResponseBody> response = environment.update(requestBody).execute();
@@ -94,7 +100,7 @@ public class EnvironmentAPITest {
 
     @Test
     @Order(5)
-    void deleteLocale() {
+    void deleteEnvironment() {
         try {
             Response<ResponseBody> response = environment.delete().execute();
             if (response.isSuccessful()) {

--- a/src/test/java/com/contentstack/cms/stack/LocaleAPITest.java
+++ b/src/test/java/com/contentstack/cms/stack/LocaleAPITest.java
@@ -3,6 +3,8 @@ package com.contentstack.cms.stack;
 import com.contentstack.cms.Contentstack;
 import com.contentstack.cms.TestClient;
 import com.contentstack.cms.Utils;
+import com.contentstack.cms.core.Util;
+
 import okhttp3.ResponseBody;
 import org.json.simple.JSONObject;
 import org.junit.jupiter.api.Assertions;
@@ -20,11 +22,14 @@ public class LocaleAPITest {
     protected static String API_KEY = TestClient.API_KEY;
     protected static String MANAGEMENT_TOKEN = TestClient.MANAGEMENT_TOKEN;
     static Locale locale;
+    protected static Stack stackInstance;
 
     @BeforeAll
     public static void setupEnv() {
-        Contentstack contentstack = new Contentstack.Builder().setAuthtoken(AUTHTOKEN).build();
-        Stack stackInstance = contentstack.stack(API_KEY, MANAGEMENT_TOKEN);
+        // Contentstack contentstack = new Contentstack.Builder().setAuthtoken(AUTHTOKEN).build();
+        // Stack stackInstance = contentstack.stack(API_KEY, MANAGEMENT_TOKEN);
+         stackInstance = TestClient.getStack().addHeader(Util.API_KEY, API_KEY)
+                .addHeader("api_key", API_KEY);
         locale = stackInstance.locale(MANAGEMENT_TOKEN);
     }
 

--- a/src/test/java/com/contentstack/cms/stack/TokenUnitTest.java
+++ b/src/test/java/com/contentstack/cms/stack/TokenUnitTest.java
@@ -100,7 +100,7 @@ class TokenUnitTest {
         Assertions.assertEquals("v3", request.url().pathSegments().get(0));
         Assertions.assertNull(request.url().encodedQuery());
         Assertions.assertEquals(
-                "https://api.contentstack.io/v3/delivery_tokens",
+                "https://api.contentstack.io/v3/stacks/delivery_tokens",
                 request.url().toString());
     }
 
@@ -116,7 +116,7 @@ class TokenUnitTest {
         Assertions.assertEquals("v3", request.url().pathSegments().get(0));
         Assertions.assertNull(request.url().encodedQuery());
         Assertions.assertEquals(
-                "https://api.contentstack.io/v3/delivery_tokens/" + _uid,
+                "https://api.contentstack.io/v3/stacks/delivery_tokens/" + _uid,
                 request.url().toString());
     }
 
@@ -132,7 +132,7 @@ class TokenUnitTest {
         Assertions.assertNotNull(request.body());
         Assertions.assertNull(request.url().encodedQuery());
         Assertions.assertEquals(
-                "https://api.contentstack.io/v3/delivery_tokens",
+                "https://api.contentstack.io/v3/stacks/delivery_tokens",
                 request.url().toString());
     }
 
@@ -146,7 +146,7 @@ class TokenUnitTest {
         Assertions.assertEquals(3, request.url().pathSegments().size());
         Assertions.assertEquals("delivery_tokens", request.url().pathSegments().get(1));
         Assertions.assertNull(request.url().encodedQuery());
-        Assertions.assertEquals("https://api.contentstack.io/v3/delivery_tokens/" + _uid, request.url().toString());
+        Assertions.assertEquals("https://api.contentstack.io/v3/stacks/delivery_tokens/" + _uid, request.url().toString());
     }
 
     @Test
@@ -159,7 +159,7 @@ class TokenUnitTest {
         Assertions.assertEquals(3, request.url().pathSegments().size());
         Assertions.assertEquals("delivery_tokens", request.url().pathSegments().get(1));
         Assertions.assertEquals("force=false", request.url().encodedQuery());
-        Assertions.assertEquals("https://api.contentstack.io/v3/delivery_tokens/" + _uid + "?force=false",
+        Assertions.assertEquals("https://api.contentstack.io/v3/stacks/delivery_tokens/" + _uid + "?force=false",
                 request.url().toString());
     }
 
@@ -173,7 +173,7 @@ class TokenUnitTest {
         Assertions.assertEquals(3, request.url().pathSegments().size());
         Assertions.assertEquals("delivery_tokens", request.url().pathSegments().get(1));
         Assertions.assertEquals("force=true", request.url().encodedQuery());
-        Assertions.assertEquals("https://api.contentstack.io/v3/delivery_tokens/" + _uid + "?force=true",
+        Assertions.assertEquals("https://api.contentstack.io/v3/stacks/delivery_tokens/" + _uid + "?force=true",
                 request.url().toString());
     }
 
@@ -188,7 +188,7 @@ class TokenUnitTest {
         Assertions.assertEquals(2, request.url().pathSegments().size());
         Assertions.assertEquals("management_tokens", request.url().pathSegments().get(1));
         Assertions.assertNull(request.url().encodedQuery());
-        Assertions.assertEquals("https://api.contentstack.io/v3/management_tokens",
+        Assertions.assertEquals("https://api.contentstack.io/v3/stacks/management_tokens",
                 request.url().toString());
     }
 
@@ -203,7 +203,7 @@ class TokenUnitTest {
         Assertions.assertEquals(3, request.url().pathSegments().size());
         Assertions.assertEquals("management_tokens", request.url().pathSegments().get(1));
         Assertions.assertNull(request.url().encodedQuery());
-        Assertions.assertEquals("https://api.contentstack.io/v3/management_tokens/" + _uid, request.url().toString());
+        Assertions.assertEquals("https://api.contentstack.io/v3/stacks/management_tokens/" + _uid, request.url().toString());
     }
 
     @Test
@@ -217,7 +217,7 @@ class TokenUnitTest {
         Assertions.assertEquals(2, request.url().pathSegments().size());
         Assertions.assertEquals("management_tokens", request.url().pathSegments().get(1));
         Assertions.assertNull(request.url().encodedQuery());
-        Assertions.assertEquals("https://api.contentstack.io/v3/management_tokens", request.url().toString());
+        Assertions.assertEquals("https://api.contentstack.io/v3/stacks/management_tokens", request.url().toString());
     }
 
     @Test
@@ -231,7 +231,7 @@ class TokenUnitTest {
         Assertions.assertEquals(3, request.url().pathSegments().size());
         Assertions.assertEquals("management_tokens", request.url().pathSegments().get(1));
         Assertions.assertNull(request.url().encodedQuery());
-        Assertions.assertEquals("https://api.contentstack.io/v3/management_tokens/" + _uid, request.url().toString());
+        Assertions.assertEquals("https://api.contentstack.io/v3/stacks/management_tokens/" + _uid, request.url().toString());
     }
 
     @Test
@@ -245,7 +245,7 @@ class TokenUnitTest {
         Assertions.assertEquals(3, request.url().pathSegments().size());
         Assertions.assertEquals("management_tokens", request.url().pathSegments().get(1));
         Assertions.assertNull(request.url().encodedQuery());
-        Assertions.assertEquals("https://api.contentstack.io/v3/management_tokens/" + _uid, request.url().toString());
+        Assertions.assertEquals("https://api.contentstack.io/v3/stacks/management_tokens/" + _uid, request.url().toString());
     }
 
     @Test
@@ -257,7 +257,7 @@ class TokenUnitTest {
         deliveryToken.addParam("key", "Value");
         deliveryToken.removeParam("key");
         Request request = tokens.deliveryTokens().find().request();
-        Assertions.assertEquals("https://api.contentstack.io/v3/delivery_tokens",
+        Assertions.assertEquals("https://api.contentstack.io/v3/stacks/delivery_tokens",
                 request.url().toString());
     }
 }


### PR DESCRIPTION
The response body was null, so passed headers in the files that were missing it.
Now able to fetch the details.