### PR TITLE
Add tests for nested global fields and API version header

### DIFF
--- a/src/main/java/com/contentstack/cms/stack/GlobalField.java
+++ b/src/main/java/com/contentstack/cms/stack/GlobalField.java
@@ -85,7 +85,11 @@ public class GlobalField implements BaseImplementation<GlobalField> {
      */
     @Override
     public GlobalField addHeader(@NotNull String key, @NotNull String value) {
-        this.headers.put(key, value);
+        if ("api_version".equalsIgnoreCase(key)) {
+            this.apiVersion = value;
+        } else {
+            this.headers.put(key, value);
+        }
         return this;
     }
 
@@ -122,6 +126,10 @@ public class GlobalField implements BaseImplementation<GlobalField> {
      */
     @Override
     public GlobalField addHeaders(@NotNull HashMap<String, String> headers) {
+        if (headers.containsKey("api_version")) {
+            this.apiVersion = headers.get("api_version");
+            headers.remove("api_version");
+        }
         this.headers.putAll(headers);
         return this;
     }

--- a/src/main/java/com/contentstack/cms/stack/GlobalField.java
+++ b/src/main/java/com/contentstack/cms/stack/GlobalField.java
@@ -37,7 +37,7 @@ public class GlobalField implements BaseImplementation<GlobalField> {
     protected HashMap<String, Object> headers;
     protected HashMap<String, Object> params;
     protected String globalFiledUid;
-
+    protected String apiVersion;
     protected GlobalField(Retrofit retrofit,Map<String, Object> headers) {
         this.headers = new HashMap<>();
         this.headers.putAll(headers);
@@ -146,6 +146,21 @@ public class GlobalField implements BaseImplementation<GlobalField> {
         this.params.clear();
         return this;
     }
+    /*
+     * For Nested Global Fields the api_version is set to 3.2 which needs 
+     * to removed from the headers inorder for other modules to function correctly
+     */
+
+    /**
+     * Returns a copy of the headers with api_version set if needed.
+     */
+    private Map<String, Object> getRequestHeaders() {
+        Map<String, Object> requestHeaders = new HashMap<>(this.headers);
+        if (this.apiVersion != null) {
+            requestHeaders.put("api_version", this.apiVersion);
+        }
+        return requestHeaders;
+    }
 
     /**
      * <b>Get All Global Fields</b>
@@ -167,11 +182,10 @@ public class GlobalField implements BaseImplementation<GlobalField> {
      * </a>
      * @see #addHeader(String, String) to add headers
      * @see #addParam(String, Object) to add query parameters
-     * @see #removeHeader(String) to remove header
      * @since 0.1.0
      */
     public Call<ResponseBody> find() {
-        return this.service.fetch(this.headers, this.params);
+        return this.service.fetch(getRequestHeaders(), this.params);
     }
 
     /**
@@ -197,12 +211,11 @@ public class GlobalField implements BaseImplementation<GlobalField> {
      * </a>
      * @see #addHeader(String, String) to add headers
      * @see #addParam(String, Object) to add query parameters
-     * @see #removeHeader(String) to remove header
      * @since 0.1.0
      */
     public Call<ResponseBody> fetch() {
         validate();
-        return this.service.single(this.headers, this.globalFiledUid, this.params);
+        return this.service.single(getRequestHeaders(), this.globalFiledUid, this.params);
     }
 
     /**
@@ -230,11 +243,10 @@ public class GlobalField implements BaseImplementation<GlobalField> {
      *
      * </a>
      * @see #addHeader(String, String) to add headers
-     * @see #removeHeader(String) to remove header
      * @since 0.1.0
      */
     public Call<ResponseBody> create(@NotNull JSONObject requestBody) {
-        return this.service.create(this.headers, requestBody);
+        return this.service.create(getRequestHeaders(), requestBody);
     }
 
     /**
@@ -260,12 +272,11 @@ public class GlobalField implements BaseImplementation<GlobalField> {
      *
      * </a>
      * @see #addHeader(String, String) to add headers
-     * @see #removeHeader(String) to remove header
      * @since 0.1.0
      */
     public Call<ResponseBody> update(@NotNull JSONObject requestBody) {
         validate();
-        return this.service.update(this.headers, this.globalFiledUid, requestBody);
+        return this.service.update(getRequestHeaders(), this.globalFiledUid, requestBody);
     }
 
     /**
@@ -286,12 +297,11 @@ public class GlobalField implements BaseImplementation<GlobalField> {
      * field
      * </a>
      * @see #addHeader(String, String) to add headers
-     * @see #removeHeader(String) to remove header
      * @since 0.1.0
      */
     public Call<ResponseBody> delete() {
         validate();
-        return this.service.delete(this.headers, this.globalFiledUid);
+        return this.service.delete(getRequestHeaders(), this.globalFiledUid);
     }
 
     /**
@@ -315,11 +325,10 @@ public class GlobalField implements BaseImplementation<GlobalField> {
      *
      * </a>
      * @see #addHeader(String, String) to add headers
-     * @see #removeHeader(String) to remove header
      * @since 0.1.0
      */
     public Call<ResponseBody> imports(@NotNull JSONObject body) {
-        return this.service.imports(this.headers, body);
+        return this.service.imports(getRequestHeaders(), body);
     }
 
     /**
@@ -336,15 +345,14 @@ public class GlobalField implements BaseImplementation<GlobalField> {
      *
      * </a>
      * @see #addHeader(String, String) to add headers
-     * @see #removeHeader(String) to remove header
      * @since 0.1.0
      */
     public Call<ResponseBody> export() {
         validate();
-        return this.service.export(this.headers, this.globalFiledUid);
+        return this.service.export(getRequestHeaders(), this.globalFiledUid);
     }
 
-     /**
+    /**
      * <b>Restore a global field </b>
      * <p>
      * The <b>Restore a global field</b> request allows you to restore the schema of
@@ -367,11 +375,10 @@ public class GlobalField implements BaseImplementation<GlobalField> {
      *
      * </a>
      * @see #addHeader(String, String) to add headers
-     * @see #removeHeader(String) to remove header
      * @since 0.1.0
      */
     public Call<ResponseBody> restore(@NotNull JSONObject requestBody) {
         validate();
-        return this.service.restore(this.headers, this.globalFiledUid, requestBody);
+        return this.service.restore(getRequestHeaders(), this.globalFiledUid, requestBody);
     }
 }

--- a/src/test/java/com/contentstack/cms/stack/GlobalFieldAPITest.java
+++ b/src/test/java/com/contentstack/cms/stack/GlobalFieldAPITest.java
@@ -1,11 +1,22 @@
 package com.contentstack.cms.stack;
 
+import java.io.IOException;
+import java.util.HashMap;
+
 import com.contentstack.cms.TestClient;
 import com.contentstack.cms.Utils;
 import com.contentstack.cms.core.Util;
+
 import okhttp3.Request;
+
 import org.json.simple.JSONObject;
 import org.junit.jupiter.api.*;
+
+import com.contentstack.cms.Contentstack;
+import com.google.gson.JsonObject;
+
+import okhttp3.ResponseBody;
+import retrofit2.Response;
 
 @Tag("unit")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -14,6 +25,7 @@ class GlobalFieldAPITest {
     public static GlobalField globalField;
     protected static String API_KEY = TestClient.API_KEY;
     protected static String MANAGEMENT_TOKEN = TestClient.MANAGEMENT_TOKEN;
+    protected static String AUTHTOKEN = TestClient.AUTHTOKEN;
     protected static String globalFieldUid = "global_field_1";
     protected static String globalFieldUid2 = "nested_global_field";
     protected static Stack stack;
@@ -326,5 +338,104 @@ class GlobalFieldAPITest {
     //     Assertions.assertEquals("restore", request.url().pathSegments().get(3));
     //     Assertions.assertNull(request.url().encodedQuery());
     // }
+
+
+    @Test
+    void testApiVersionHeaderIsSet() {
+        HashMap<String, Object> headers = new HashMap<>();
+        headers.put(Util.API_KEY, API_KEY);
+        headers.put(Util.AUTHORIZATION, MANAGEMENT_TOKEN);
+        String apiVersion = "3.2";
+        Stack stack = new Contentstack.Builder().setAuthtoken(AUTHTOKEN).build().stack(headers);
+        GlobalField gfWithApiVersion = new GlobalField(stack.client, stack.headers, "feature");
+        gfWithApiVersion.addHeader("api_version", apiVersion);
+        Request request = gfWithApiVersion.fetch().request();
+        Assertions.assertEquals(apiVersion, request.header("api_version"));
+    }
+
+    // --- Nested Global Field Test Suite ---
+    @Nested
+    @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+    class NestedGlobalFieldTests {
+        GlobalField nestedGlobalField;
+        String nestedUid = "nested_global_field";
+        String apiVersion = "3.2";
+
+        @BeforeEach
+        void setupNested() {
+            HashMap<String, Object> headers = new HashMap<>();
+            headers.put(Util.API_KEY, API_KEY);
+            headers.put(Util.AUTHORIZATION, MANAGEMENT_TOKEN);
+            Stack stack = new Contentstack.Builder().setAuthtoken(AUTHTOKEN).build().stack(headers);
+            nestedGlobalField = new GlobalField(stack.client, stack.headers, nestedUid);
+            nestedGlobalField.addHeader("api_version", apiVersion);
+        }
+
+        @Test
+        @Order(1)
+        void testCreateNestedGlobalField() throws IOException {
+            JSONObject requestBody = Utils.readJson("globalfield/nested_global_field.json");
+            Request request = nestedGlobalField.create(requestBody).request();
+            Assertions.assertEquals("https://api.contentstack.io/v3/global_fields", request.url().toString());
+            Assertions.assertEquals("/v3/global_fields", request.url().encodedPath());
+            Assertions.assertEquals("https", request.url().scheme());
+            Assertions.assertEquals("POST", request.method());
+            Assertions.assertEquals(apiVersion, request.header("api_version"));
+            Response<ResponseBody> response = nestedGlobalField.create(requestBody).execute();
+            Assertions.assertEquals(201, response.code());
+        }
+
+        @Test
+        @Order(2)
+        void testGetNestedGlobalField() throws IOException{ 
+            nestedGlobalField.addParam("include_global_fields", true);
+            nestedGlobalField.addParam("include_validation_keys", true);
+            Request request = nestedGlobalField.fetch().request();
+            Assertions.assertEquals("https://api.contentstack.io/v3/global_fields/" + nestedUid + "?include_global_fields=true&include_validation_keys=true", request.url().toString());
+            Assertions.assertEquals("https", request.url().scheme());
+            Assertions.assertEquals("GET", request.method());
+            Assertions.assertEquals(apiVersion, request.header("api_version"));
+            Response<ResponseBody> response = nestedGlobalField.fetch().execute();
+            Assertions.assertEquals(200, response.code());
+            JsonObject responseBody = Utils.toJson(response).getAsJsonObject();
+            JsonObject globalField = responseBody.getAsJsonObject("global_field");
+            Assertions.assertEquals("Nested Global Field", globalField.get("title").getAsString());
+            Assertions.assertTrue(globalField.has("referred_global_fields"));
+            Assertions.assertTrue(globalField.has("validation_keys"));
+        }
+
+        @Test
+        @Order(3)
+        void testUpdateNestedGlobalField() throws IOException {
+            JSONObject requestBody = Utils.readJson("globalfield/nested_global_field_update1.json");
+            Request request = nestedGlobalField.update(requestBody).request();
+            Assertions.assertEquals("https://api.contentstack.io/v3/global_fields/" + nestedUid, request.url().toString());
+            Assertions.assertEquals("/v3/global_fields/" + nestedUid, request.url().encodedPath());
+            Assertions.assertEquals("https", request.url().scheme());
+            Assertions.assertEquals("PUT", request.method());
+            Assertions.assertEquals(apiVersion, request.header("api_version"));
+            Response<ResponseBody> response = nestedGlobalField.update(requestBody).execute();
+            Assertions.assertEquals(200, response.code());
+            JsonObject responseBody = Utils.toJson(response).getAsJsonObject();
+            JsonObject globalField = responseBody.getAsJsonObject("global_field");
+            Assertions.assertEquals("Nested Global Field", globalField.get("title").getAsString());
+            
+        }
+
+        @Test
+        @Order(4)
+        void testDeleteNestedGlobalField() throws IOException {
+            Request request = nestedGlobalField.delete().request();
+            Assertions.assertEquals("https://api.contentstack.io/v3/global_fields/" + nestedUid + "?force=true", request.url().toString());
+            Assertions.assertEquals("https", request.url().scheme());
+            Assertions.assertEquals("DELETE", request.method());
+            Assertions.assertEquals(apiVersion, request.header("api_version"));
+            Response<ResponseBody> response = nestedGlobalField.delete().execute();
+            Assertions.assertEquals(200, response.code());
+            JsonObject responseBody = Utils.toJson(response).getAsJsonObject();
+            Assertions.assertEquals("Global Field deleted successfully.", responseBody.get("notice").getAsString());
+        }
+    }
+
 
 }

--- a/src/test/resources/globalfield/nested_global_field.json
+++ b/src/test/resources/globalfield/nested_global_field.json
@@ -1,0 +1,44 @@
+{
+    "global_field": {
+        "title": "Nested Global Field",
+        "uid": "nested_global_field",
+        "description": "",
+        "schema": [
+            {
+                "data_type": "text",
+                "display_name": "Single Line Textbox",
+                "uid": "single_line",
+                "field_metadata": {
+                    "description": "",
+                    "default_value": "",
+                    "version": 3
+                },
+                "format": "",
+                "error_messages": {
+                    "format": ""
+                },
+                "mandatory": false,
+                "multiple": false,
+                "non_localizable": false,
+                "unique": false,
+                "indexed": false,
+                "inbuilt_model": false
+            },
+            {
+                "data_type": "global_field",
+                "display_name": "SEO",
+                "reference_to": "seo",
+                "field_metadata": {
+                    "description": ""
+                },
+                "uid": "seo",
+                "mandatory": false,
+                "multiple": false,
+                "non_localizable": false,
+                "unique": false,
+                "indexed": false,
+                "inbuilt_model": false
+            }
+        ]
+    }
+}

--- a/src/test/resources/globalfield/nested_global_field_update1.json
+++ b/src/test/resources/globalfield/nested_global_field_update1.json
@@ -1,0 +1,59 @@
+{
+    "global_field": {
+        "title": "Nested Global Field",
+        "uid": "nested_global_field",
+        "description": "",
+        "schema": [
+            {
+                "data_type": "text",
+                "display_name": "Single Line Textbox",
+                "uid": "single_line",
+                "field_metadata": {
+                    "description": "",
+                    "default_value": "",
+                    "version": 3
+                },
+                "format": "",
+                "error_messages": {
+                    "format": ""
+                },
+                "mandatory": false,
+                "multiple": false,
+                "non_localizable": false,
+                "unique": false,
+                "indexed": false,
+                "inbuilt_model": false
+            },
+            {
+                "data_type": "global_field",
+                "display_name": "SEO",
+                "reference_to": "seo",
+                "field_metadata": {
+                    "description": ""
+                },
+                "uid": "seo",
+                "mandatory": false,
+                "multiple": false,
+                "non_localizable": false,
+                "unique": false,
+                "indexed": false,
+                "inbuilt_model": false
+            },
+            {
+                "data_type": "global_field",
+                "display_name": "feature",
+                "reference_to": "feature",
+                "field_metadata": {
+                    "description": ""
+                },
+                "uid": "feature",
+                "mandatory": false,
+                "multiple": false,
+                "non_localizable": false,
+                "unique": false,
+                "indexed": false,
+                "inbuilt_model": false
+            }
+        ]
+    }
+}


### PR DESCRIPTION
- Implemented unit tests for creating, fetching, updating, and deleting nested global fields in GlobalFieldAPITest.
- Added a test to verify that the API version header is correctly set in requests.